### PR TITLE
Allow lzma compressed data file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,29 @@
+from setuptools import setup
+from setuptools.command.build_py import build_py
+import lzma
+import os
+
+
+class compress_data(build_py):
+
+    _data = [('conway_polynomials', 'CPimport.txt')]
+
+    def compress(self):
+        """ Compress data files into build directory"""
+        for pkg, filename in self._data:
+            src = os.path.join(self.build_lib, pkg, filename)
+            dst = os.path.join(self.build_lib, pkg, filename + '.xz')
+            print(f"compressing {src} -> {dst}")
+            with open(src, "rb") as s:
+                with lzma.open(dst, "w") as d:
+                    d.write(s.read())
+            os.remove(src)
+
+    def run(self):
+        build_py.run(self)
+        self.compress()
+
+
+cmdclass = {'build_py': compress_data}
+
+setup(cmdclass=cmdclass)

--- a/src/conway_polynomials/__init__.py
+++ b/src/conway_polynomials/__init__.py
@@ -89,6 +89,17 @@ def _parse_line(l: str) -> tuple[int, int, tuple[int,...]]:
 
     return (p, n, coeffs)
 
+def _open_database():
+    r"""
+    Open the database, possibly xz compressed.
+    """
+    from importlib.resources import files
+    dbpath = files('conway_polynomials').joinpath('CPimport.txt')
+    try:
+        import lzma
+        return lzma.open(dbpath.with_suffix(".txt.xz"), "rt")
+    except FileNotFoundError:
+        return dbpath.open("r")
 
 from typing import Optional
 _conway_dict: Optional[ dict[int,dict[int,tuple[int,...]]] ]
@@ -117,9 +128,7 @@ def database() -> dict[int,dict[int,tuple[int,...]]]:
         return _conway_dict
 
     _conway_dict = {}
-    from importlib.resources import files
-    dbpath = files('conway_polynomials').joinpath('CPimport.txt')
-    with dbpath.open("r") as f:
+    with _open_database() as f:
         # The first line of the file is "allConwayPolynomials := ["
         f.readline()
 


### PR DESCRIPTION
An attempt at #3.

This will use `CPimport.txt.lzma` if available, else fallback to `CPimport.txt` as before.

Note that this doesn't attempt to compress the file at install time, since I don't know how to do that. But one could e.g. compress the file when packaging for a distro, and it would work transparently. I do this for pari data, which support replacing text files by gzipped files.